### PR TITLE
Avoid deadlocking when going cold.

### DIFF
--- a/src/vmod_dynamic.c
+++ b/src/vmod_dynamic.c
@@ -398,6 +398,13 @@ dynamic_lookup_thread(void *obj)
 
 		ret = getaddrinfo(dom->addr, dom->obj->port, &hints, &res);
 
+		/*
+		 * If obj isn't active after the blocking call,
+		 * there's no point going forward
+		 */
+		if (!dom->obj->active)
+			break;
+
 		if (ret == 0) {
 			dynamic_update(dom, res);
 			freeaddrinfo(res);


### PR DESCRIPTION
When we receive a cold/discard vmod event, we do a pthread_join with
obj->mtx held.

This creates the possibility for a deadlock if, at the same time we're
about to pthread_join, another thread is in dynamic_update, which tries
to hold the same mutex:


```
vmod_event                                       thread_A
obj->active = 0
lock(obj->mtx)
.
.                                                lock(obj->mtx)   -> deadlocks
.                                                .
pthread_join(thread_A)                           .
.                                                .
.                                                unlock(obj->mtx)
.
unlock(obj->mtx)

```
The solution is after we get the DNS results, we do an early check if
the obj is still active. If it's not, just exit there and finish the
thread.

This fixes https://github.com/varnishcache/varnish-cache/issues/2103