### PR TITLE
Avoid deadlocking when going cold - take 2

### DIFF
--- a/src/vmod_dynamic.c
+++ b/src/vmod_dynamic.c
@@ -397,6 +397,15 @@ dynamic_lookup_thread(void *obj)
 	while (dom->obj->active && dom->status <= DYNAMIC_ST_ACTIVE) {
 
 		ret = getaddrinfo(dom->addr, dom->obj->port, &hints, &res);
+		/*
+		 * If obj isn't active after the blocking call,
+		 * there's no point going forward
+		 */
+		if (!dom->obj->active) {
+			freeaddrinfo(res);
+			break;
+		}
+
 
 		if (ret == 0) {
 			dynamic_update(dom, res);


### PR DESCRIPTION
When we receive a cold/discard vmod event, we do a pthread_join with
obj->mtx held.

This creates the possibility for a deadlock if, at the same time we're
about to pthread_join, another thread is in dynamic_update, which tries
to hold the same mutex:

```
vmod_event                         thread_A
obj->active = 0
lock(obj->mtx)
.
.                                  lock(obj->mtx)       -> deadlock
.                                  .
pthread_join(thread_A)             .
.                                  .
.                                  unlock(obj->mtx)
.
unlock(obj->mtx)

```
The solution is after we get the DNS results, we do an early check if
the obj is still active. If it's not, just exit there and finish the
thread.

Since we're dropping the update and exiting the thread, the user can be confused if this is logged in SLT_Error or SLT_VCL_Log.

This fixes varnishcache/varnish-cache#2103