### PR TITLE
Never allow a NULL reference in dom->current

### DIFF
--- a/src/vmod_dynamic.c
+++ b/src/vmod_dynamic.c
@@ -119,6 +119,9 @@ dynamic_resolve(const struct director *d, struct worker *wrk,
 		return (NULL);
 	}
 
+	if (dom->current == NULL)
+		dom->current = VTAILQ_FIRST(&dom->refs);
+
 	next = dom->current;
 
 	do {
@@ -208,6 +211,9 @@ dynamic_del(VRT_CTX, struct dynamic_ref *r)
 
 	if (r == dom->current)
 		dom->current = VTAILQ_NEXT(r, list);
+
+	if (dom->current == NULL)
+		dom->current = VTAILQ_FIRST(&dom->refs);
 
 	VTAILQ_REMOVE(&dom->refs, r, list);
 	free(r);


### PR DESCRIPTION
If dom->current is the very last position on the queue and we're going
to delete it, VTAILQ_NEXT is going to be NULL. When this happens,
go back to the first element.

This fixes issue #7