### PR TITLE
Fix use-after-free

### DIFF
--- a/src/vmod_dynamic.c
+++ b/src/vmod_dynamic.c
@@ -560,8 +560,8 @@ dynamic_stop(struct vmod_dynamic_director *obj)
 		AZ(pthread_join(dom->thread, NULL));
 		assert(dom->status == DYNAMIC_ST_DONE);
 		dom->status = DYNAMIC_ST_READY;
-		dynamic_free(NULL, dom);
 		VTAILQ_REMOVE(&dom->obj->purged_domains, dom, list);
+		dynamic_free(NULL, dom);
 	}
 
 	INIT_OBJ(&ctx, VRT_CTX_MAGIC);


### PR DESCRIPTION
Clang's static analyzer found a use-after-free in dynamic_stop().  dom
pointer is passed to dynamic_free() which deallocate its contents, but
upon returning from dynamic_free(), dom and its possibly-stale contents
are used unguarded in VTAILQ_REMOVE(), immediately.

This use-after-free could explain the hard-to-reproduce issue #7.