### PR TITLE
Fix #9 in two parts

### DIFF
--- a/src/vmod_dynamic.c
+++ b/src/vmod_dynamic.c
@@ -625,6 +625,10 @@ dynamic_search(VRT_CTX, struct vmod_dynamic_director *obj, const char *addr)
 		}
 	}
 
+	/* Leave early if there is no work to be done. */
+	if (dom == NULL)
+		return NULL;
+
 	VTAILQ_FOREACH_SAFE(d, &obj->purged_domains, list, d2) {
 		CHECK_OBJ_NOTNULL(d, DYNAMIC_DOMAIN_MAGIC);
 		if (d->status == DYNAMIC_ST_DONE) {

--- a/src/vmod_dynamic.c
+++ b/src/vmod_dynamic.c
@@ -560,8 +560,8 @@ dynamic_stop(struct vmod_dynamic_director *obj)
 		AZ(pthread_join(dom->thread, NULL));
 		assert(dom->status == DYNAMIC_ST_DONE);
 		dom->status = DYNAMIC_ST_READY;
-		dynamic_free(NULL, dom);
 		VTAILQ_REMOVE(&dom->obj->purged_domains, dom, list);
+		dynamic_free(NULL, dom);
 	}
 
 	INIT_OBJ(&ctx, VRT_CTX_MAGIC);

--- a/src/vmod_dynamic.c
+++ b/src/vmod_dynamic.c
@@ -633,8 +633,8 @@ dynamic_search(VRT_CTX, struct vmod_dynamic_director *obj, const char *addr)
 			d->thread = 0;
 			d->status = DYNAMIC_ST_READY;
 			Lck_Unlock(&d->mtx);
-			dynamic_free(ctx, d);
 			VTAILQ_REMOVE(&dom->obj->purged_domains, d, list);
+			dynamic_free(ctx, d);
 		}
 	}
 
@@ -814,15 +814,15 @@ vmod_director__fini(struct vmod_dynamic_director **objp)
 
 	/* Backends will be deleted by the VCL, pass a NULL struct ctx */
 	while (!VTAILQ_EMPTY(&obj->purged_domains)) {
-		dynamic_free(NULL, VTAILQ_FIRST(&obj->purged_domains));
 		VTAILQ_REMOVE(&obj->purged_domains,
 		    VTAILQ_FIRST(&obj->purged_domains), list);
+		dynamic_free(NULL, VTAILQ_FIRST(&obj->purged_domains));
 	}
 
 	while (!VTAILQ_EMPTY(&obj->active_domains)) {
-		dynamic_free(NULL, VTAILQ_FIRST(&obj->active_domains));
 		VTAILQ_REMOVE(&obj->active_domains,
 		    VTAILQ_FIRST(&obj->active_domains), list);
+		dynamic_free(NULL, VTAILQ_FIRST(&obj->active_domains));
 	}
 
 	assert(VTAILQ_EMPTY(&obj->backends));


### PR DESCRIPTION
With the patches in this PR, I cannot reproduce the problem proposed in #9 anymore.

The first commit fixes three other cases of use-after-free.  While inspecting `dynamic_free()`, it is my understanding that given the opportunity, memory being accessed just after deallocation could lead to unexpected results.  By itself, this commit does not fix #9.

The second commit avoids cleaning up the `purged_domains` list in the case domain `addr` (received in `dynamic_search()`) was not found in the `active_domains` list, thus leaving `dom` uninitialized.

Please review, since this might not be a trivial change.