### PR TITLE
Test with a dedicated hosts file if possible

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -61,7 +61,21 @@ pkg-config and Varnish. You can build the module simply by running::
  ./configure
  make
 
-For the test suite to work, please add this line to your ``/etc/hosts``::
+For the test suite to work, your best shot is to install nss_wrapper_
+and add it to your environment before you run ``./configure``::
+
+    export LD_PRELOAD=libnss_wrapper.so
+
+.. _nss_wrapper: https://cwrap.org
+
+On multi-lib systems you may run into problems. For example you may be
+building against a 64-bit Varnish, but the test suite may use a 32-bit
+program that will fail to honor the preload. In that case your system
+may support multi-lib preload too::
+
+    export LD_PRELOAD_64=libnss_wrapper.so
+
+If it still doesn't work, you can add this line to your ``/etc/hosts``::
 
 	127.0.0.1 www.localhost img.localhost
 
@@ -69,7 +83,8 @@ then run::
 
 	make check
 
-Alternatively, the ``make check`` can also be skipped.
+Alternatively, the ``make check`` can also be skipped. It is automatically
+skipped if ``./configure`` couldn't determine it would work.
 
 You can then proceed with the installation::
 

--- a/configure.ac
+++ b/configure.ac
@@ -31,6 +31,22 @@ AC_SUBST([VARNISH_LIBRARY_PATH],
 
 AC_SUBST([VTC_TESTS], "$(cd $srcdir/src && echo tests/*.vtc)")
 
+# Check that either cwrap is properly set up or the global hosts
+# file contains the loop-back domains used in the test suite.
+NSS_WRAPPER_HOSTS="$PWD/$srcdir/src/tests/hosts" \
+LD_LIBRARY_PATH="$VARNISH_LIBRARY_PATH" \
+PATH="$VMOD_TEST_PATH:$PATH" \
+env varnishtest -v $srcdir/src/tests/check-hosts.vtc 1>&5 2>&5 ||
+VTC_TESTS=
+
+AC_MSG_CHECKING([that the test suite works])
+if test -n "$VTC_TESTS"
+then
+	AC_MSG_RESULT([yes])
+else
+	AC_MSG_RESULT([no])
+fi
+
 AS_VERSION_COMPARE([$VARNISH_VERSION], [5.0], [
 	AC_DEFINE([HAVE_VCL_EVENT_USE], [1], [Define if USE events are sent.])])
 

--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -21,7 +21,8 @@ pdf-local: vmod_dynamic.pdf
 @BUILD_VMOD_DYNAMIC@
 
 AM_TESTS_ENVIRONMENT = \
-	PATH="$(VMOD_TEST_PATH)" \
+	NSS_WRAPPER_HOSTS="$(abs_srcdir)/tests/hosts" \
+	PATH="$(VMOD_TEST_PATH):$(PATH)" \
 	LD_LIBRARY_PATH="$(VARNISH_LIBRARY_PATH)"
 TEST_EXTENSIONS = .vtc
 VTC_LOG_COMPILER = varnishtest -v

--- a/src/tests/check-hosts.vtc
+++ b/src/tests/check-hosts.vtc
@@ -1,0 +1,33 @@
+varnishtest "hosts check for the test suite"
+
+shell {
+	set -e
+
+	# sanity checks
+	getent hosts 127.0.0.1
+	getent hosts ::1
+
+	# domains checks
+	getent hosts 127.0.0.1 | grep -w localhost
+	getent hosts 127.0.0.1 | grep -w localhost
+	getent hosts 127.0.0.1 | grep -w www.localhost
+	getent hosts 127.0.0.1 | grep -w img.localhost
+
+	getent hosts ::1 | grep -w localhost
+	getent hosts ::1 | grep -w localhost
+	getent hosts ::1 | grep -w www.localhost
+	getent hosts ::1 | grep -w img.localhost
+}
+
+# we also need barrier support in varnishtest
+barrier b1 cond 2
+
+server s1 {
+	barrier b1 sync
+} -start
+
+client c1 -connect ${s1_sock} {
+	barrier b1 sync
+} -run
+
+server s1 -wait

--- a/src/tests/hosts
+++ b/src/tests/hosts
@@ -1,0 +1,2 @@
+127.0.0.1 localhost localhost4 www.localhost img.localhost
+::1       localhost localhost6 www.localhost img.localhost


### PR DESCRIPTION
Ironically, this breaks my setup. I never needed to tweak my NSS
configuration or add entries to /etc/hosts to resolve *.localhost
to the loop-back interface.

However, we can now guess at configure time whether the test suite
is expected to work. Although there's no real guarantee because of
the huge TOCTOU race between `./configure` and `make check`.