### PR TITLE
Add missing headers when building under FreeBSD + FreeBSD installation instructions

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -121,9 +121,11 @@ FreeBSD
 FreeBSD users may install from either the ports tree or via packages:
 
 * via the Ports Tree
+
   ``cd /usr/ports/www/varnish-libvmod-dynamic/ && make install clean``
 
 * via the Package
+
   ``pkg install varnish-libvmod-dynamic``
 
 RPMs

--- a/README.rst
+++ b/README.rst
@@ -115,6 +115,17 @@ By default, the vmod ``configure`` script installs the built vmod in the
 directory relevant to the prefix. The vmod installation directory can be
 overridden by passing the ``vmoddir`` variable to ``make install``.
 
+FreeBSD
+-------
+
+FreeBSD users may install from either the ports tree or via packages:
+
+* via the Ports Tree
+  ``cd /usr/ports/www/varnish-libvmod-dynamic/ && make install clean``
+
+* via the Package
+  ``pkg install varnish-libvmod-dynamic``
+
 RPMs
 ----
 

--- a/src/dyn_resolver_getdns.c
+++ b/src/dyn_resolver_getdns.c
@@ -33,6 +33,12 @@
 #include <sys/socket.h>
 #include <netdb.h>
 
+#ifdef __FreeBSD__
+#include <arpa/inet.h>
+#include <netinet/in.h>
+#include <resolv.h>
+#endif
+
 #include <cache/cache.h>
 #include <vsa.h>
 


### PR DESCRIPTION
Currently fails to build under FreeBSD 11.3 without these includes.