### PR TITLE
Enable use of dynamic.backend() in vcl_init.

### DIFF
--- a/src/tests/test14.vtc
+++ b/src/tests/test14.vtc
@@ -1,0 +1,51 @@
+varnishtest "layer dynamic with another director"
+
+# This also tests the use of .backend() in vcl_init, which can be used
+# by other VMODs that initialize with a backend.
+
+feature cmd "getent hosts www.localhost img.localhost"
+
+server s1 {
+	rxreq
+	txresp
+
+	rxreq
+	txresp
+} -start
+
+varnish v1 -vcl {
+	import ${vmod_dynamic};
+	import directors;
+
+	backend dummy None;
+
+	sub vcl_init {
+		new d1 = dynamic.director(port = "${s1_port}");
+
+		new rr = directors.round_robin();
+		rr.add_backend(d1.backend("www.localhost"));
+		rr.add_backend(d1.backend("img.localhost"));
+	}
+
+	sub vcl_recv {
+		set req.backend_hint = rr.backend();
+		return(pass);
+	}
+
+	sub vcl_backend_error {
+		# the director may resolve ::1 first
+		return (retry);
+	}
+} -start
+
+client c1 {
+	txreq
+	rxresp
+	expect resp.status == 200
+
+	txreq -hdr "Connection: close"
+	rxresp
+	expect resp.status == 200
+} -run
+
+server s1 -wait

--- a/src/vmod_dynamic.c
+++ b/src/vmod_dynamic.c
@@ -731,7 +731,9 @@ dynamic_get(VRT_CTX, struct vmod_dynamic_director *obj, const char *addr,
 	AZ(pthread_cond_init(&dom->cond, NULL));
 	AZ(pthread_cond_init(&dom->resolve, NULL));
 
-	AZ(pthread_create(&dom->thread, NULL, &dynamic_lookup_thread, dom));
+	if (ctx->method != VCL_MET_INIT)
+		AZ(pthread_create(&dom->thread, NULL, &dynamic_lookup_thread,
+			dom));
 
 	VTAILQ_INSERT_TAIL(&obj->active_domains, dom, list);
 


### PR DESCRIPTION
I'm not sure if this is right, so I'm primarily asking for review and feedback. (But of course the PR can be merged if it is right.)

That is, I'm not sure if it's enough just to decline starting the lookup thread when `.backend()` is called in `vcl_init`, or if there are other conditions and/or invariants that might be violated.

I'm also not sure if the added check in `.backend()` is strictly necessary -- load failure if the `.host` field is not set. It just doesn't make much sense to me to use `.backend()` in `vcl_init` unless you are providing a host to look up.

And I haven't thought of a way to write a vtc test without installing another VMOD, since you need something that uses a BACKEND in `vcl_init`. I tested with this VCL using VMOD re2:
```
vcl 4.1;

import re2;
import dynamic;

backend fail None;

sub vcl_init {
        new d = dynamic.director();
        d.debug(true);

        new r = re2.set(literal=true, anchor=both);
        r.add("one", backend=d.backend("one.test.uplex.de"));
        r.add("two-a", backend=d.backend("two-a.test.uplex.de"));
        r.add("two-b", backend=d.backend("two-b.test.uplex.de"));
        r.compile();
}

sub vcl_recv {
        set req.backend_hint = fail;
        if (r.match(req.http.Domain)) {
                set req.backend_hint = r.backend();
        }
}
```

Before the change, calling `.backend()` in `vcl_init` resulted in assertion failure, since the lookup thread was started by both `dynamic_get()` (called by the method implementation) and `dynamic_start()` (called by the event handler). Obviously we wouldn't want two threads running when one is enough. But it also violated assumptions about the state enum:
```
Debug: Child (16913) Started
Error: Child (16913) not responding to CLI, killed it.
CLI result = 400
Error: Child (16913) Pushing vcls failed:
CLI communication error (hdr)
Debug: Stopping Child
Error: Child (16913) died signal=6 (core dumped)
Error: Child (16913) Panic at: Tue, 23 Jun 2020 12:40:35 GMT
Assert error in dynamic_start(), vmod_dynamic.c line 646:
  Condition(dom->status == DYNAMIC_ST_READY) not true.
```
This was because `.backend()` was called first, which started the thread and changed the state before the evnt handler ran and called `dynamic_start()`.

With the change in the PR, I get the expected result:
```
# varnish listening at port :8080
$ curl -I -X GET -H 'Domain: one' -H 'Host: one.test.uplex.de' http://localhost:8080
HTTP/1.1 302 Found
Date: Tue, 23 Jun 2020 15:42:36 GMT
Server: Varnish
X-Varnish: 18335502
Location: https://one.test.uplex.de/
Content-Length: 0
X-Varnish: 32773
Age: 0
Via: 1.1 varnish (Varnish/6.4)
Connection: keep-alive
```
The redirect response to https matches the response you get for `http://one.test.uplex.de`, and the same thing happens for the `two-a` and `two-b` domains.

I also see the Timestamps from VMOD dynamic as expected in the log:
```
$ varnishlog -g raw -q 'vxid == 0 and Timestamp' -d
         0 Timestamp      - vmod-dynamic boot.d(one.test.uplex.de:http) Lookup: 1592925593.002916 0.000000 0.000000
         0 Timestamp      - vmod-dynamic boot.d(two-a.test.uplex.de:http) Lookup: 1592925593.002975 0.000000 0.000000
         0 Timestamp      - vmod-dynamic boot.d(two-b.test.uplex.de:http) Lookup: 1592925593.002990 0.000000 0.000000
         0 Timestamp      - vmod-dynamic boot.d(one.test.uplex.de:http) Results: 1592925593.006311 0.003395 0.003395
         0 Timestamp      - vmod-dynamic boot.d(one.test.uplex.de:http) Update: 1592925593.006472 0.003555 0.000160
         0 Timestamp      - vmod-dynamic boot.d(two-b.test.uplex.de:http) Results: 1592925593.007160 0.004170 0.004170
         0 Timestamp      - vmod-dynamic boot.d(two-b.test.uplex.de:http) Update: 1592925593.007166 0.004176 0.000006
         0 Timestamp      - vmod-dynamic boot.d(two-a.test.uplex.de:http) Results: 1592925593.007333 0.004358 0.004358
         0 Timestamp      - vmod-dynamic boot.d(two-a.test.uplex.de:http) Update: 1592925593.007339 0.004364 0.000006
```
@nigoroll have I overlooked anything? (Could it be this easy?)