### PR TITLE
Add version 2.2.1

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -2,7 +2,7 @@
 vmod-dynamic
 ============
 
-This branch is for varnish 6.3, 6.4 and master
+This branch is for varnish 6.4 and master
 
 Description
 ===========

--- a/configure.ac
+++ b/configure.ac
@@ -1,5 +1,5 @@
 AC_PREREQ([2.68])
-AC_INIT([libvmod-dynamic], [trunk], [varnish-support@uplex.de], [vmod-dynamic])
+AC_INIT([libvmod-dynamic], [2.2.1], [varnish-support@uplex.de], [vmod-dynamic])
 AC_COPYRIGHT([Copyright 2019 UPLEX - Nils Goroll Systemoptimierung])
 AC_CONFIG_MACRO_DIR([m4])
 AC_CONFIG_AUX_DIR([build-aux])

--- a/configure.ac
+++ b/configure.ac
@@ -1,5 +1,5 @@
 AC_PREREQ([2.68])
-AC_INIT([libvmod-dynamic], [2.2.1], [varnish-support@uplex.de], [vmod-dynamic])
+AC_INIT([libvmod-dynamic], [trunk], [varnish-support@uplex.de], [vmod-dynamic])
 AC_COPYRIGHT([Copyright 2019 UPLEX - Nils Goroll Systemoptimierung])
 AC_CONFIG_MACRO_DIR([m4])
 AC_CONFIG_AUX_DIR([build-aux])


### PR DESCRIPTION
This adds version 2.2.1, which I used to build a new RPM that is compatible with Varnish 6.4.0 and adds the recent new feature (calling `.backend()` in `vcl_init`, layering dynamic with other directors). The RPM is already available at http://pkg.uplex.de.

@nigoroll as with version 2.1.1 on branch 6.3, you'll probably have to apply tag v2.2.1 to commit 109a7300a1f9a128ddd79d6bddf7595770f56ee5 -- I did that in the fork, but tags are not merged with a github PR.