### PR TITLE
Add the authority parameter to .director().

### DIFF
--- a/src/tests/via.vtc
+++ b/src/tests/via.vtc
@@ -10,6 +10,7 @@ server s1 {
 varnish v2 -proto PROXY -vcl {
 	import ${vmod_dynamic};
 	import std;
+	import proxy;
 
 	backend dummy { .host = "${bad_backend}"; }
 
@@ -20,7 +21,13 @@ varnish v2 -proto PROXY -vcl {
 	sub vcl_recv {
 		set req.backend_hint = d1.backend(server.ip,
 		    std.port(server.ip));
+		set req.http.Authority = proxy.authority();
+
 		return (pass);
+	}
+
+	sub vcl_deliver {
+		set resp.http.Authority = req.http.Authority;
 	}
 } -start
 
@@ -49,11 +56,12 @@ client c1 {
 	txreq
 	rxresp
 	expect resp.status == 200
+	expect resp.http.Authority == "localhost"
 } -run
-
-varnish v1 -expect VBE.vcl1.d1(${s1_addr}:${s1_port}).req == 1
-varnish v1 -expect LCK.dynamic.director.creat > 0
-varnish v1 -expect LCK.dynamic.backend.creat > 0
 
 # vtc diag only
 shell "varnishstat -1 -n ${v1_name} -f VBE.*"
+
+varnish v1 -expect VBE.vcl1.d1.localhost(${s1_addr}:${s1_port}).req == 1
+varnish v1 -expect LCK.dynamic.director.creat > 0
+varnish v1 -expect LCK.dynamic.backend.creat > 0

--- a/src/tests/via.vtc
+++ b/src/tests/via.vtc
@@ -1,0 +1,59 @@
+varnishtest "via"
+
+shell "getent hosts localhost www.localhost img.localhost || true"
+
+server s1 {
+	rxreq
+	txresp
+} -start
+
+varnish v2 -proto PROXY -vcl {
+	import ${vmod_dynamic};
+	import std;
+
+	backend dummy { .host = "${bad_backend}"; }
+
+	sub vcl_init {
+		new d1 = dynamic.director();
+	}
+
+	sub vcl_recv {
+		set req.backend_hint = d1.backend(server.ip,
+		    std.port(server.ip));
+		return (pass);
+	}
+} -start
+
+varnish v1 -vcl {
+	import ${vmod_dynamic};
+
+	backend v2 { .host = "${v2_addr}"; .port = "${v2_port}"; }
+
+	sub vcl_init {
+		new d1 = dynamic.director(
+		    port = "${s1_port}",
+		    via = v2);
+	}
+
+	sub vcl_recv {
+		set req.backend_hint = d1.backend("localhost");
+	}
+
+	sub vcl_backend_error {
+		# the director may resolve ::1 first
+		return (retry);
+	}
+} -start
+
+client c1 {
+	txreq
+	rxresp
+	expect resp.status == 200
+} -run
+
+varnish v1 -expect VBE.vcl1.d1(${s1_addr}:${s1_port}).req == 1
+varnish v1 -expect LCK.dynamic.director.creat > 0
+varnish v1 -expect LCK.dynamic.backend.creat > 0
+
+# vtc diag only
+shell "varnishstat -1 -n ${v1_name} -f VBE.*"

--- a/src/tests/via.vtc
+++ b/src/tests/via.vtc
@@ -1,8 +1,8 @@
-varnishtest "via"
+varnishtest "via and authority"
 
 shell "getent hosts localhost www.localhost img.localhost || true"
 
-server s1 {
+server s1 -repeat 5 {
 	rxreq
 	txresp
 } -start
@@ -57,6 +57,135 @@ client c1 {
 	rxresp
 	expect resp.status == 200
 	expect resp.http.Authority == "localhost"
+} -run
+
+varnish v1 -vcl {
+	import ${vmod_dynamic};
+
+	backend v2 { .host = "${v2_addr}"; .port = "${v2_port}"; }
+
+	sub vcl_init {
+		new d1 = dynamic.director(
+		    port = "${s1_port}",
+		    via = v2,
+		    authority = "authority.com");
+	}
+
+	sub vcl_recv {
+		set req.backend_hint = d1.backend("localhost");
+	}
+
+	sub vcl_backend_error {
+		# the director may resolve ::1 first
+		return (retry);
+	}
+}
+
+client c1 {
+	txreq -url /foo
+	rxresp
+	expect resp.status == 200
+	expect resp.http.Authority == "authority.com"
+} -run
+
+varnish v1 -vcl {
+	import ${vmod_dynamic};
+
+	backend v2 { .host = "${v2_addr}"; .port = "${v2_port}"; }
+
+	sub vcl_init {
+		new d1 = dynamic.director(
+		    port = "${s1_port}",
+		    via = v2,
+		    host_header = "host.com");
+	}
+
+	sub vcl_recv {
+		set req.backend_hint = d1.backend("localhost");
+	}
+
+	sub vcl_backend_error {
+		# the director may resolve ::1 first
+		return (retry);
+	}
+}
+
+client c1 {
+	txreq -url /bar
+	rxresp
+	expect resp.status == 200
+	expect resp.http.Authority == "host.com"
+} -run
+
+varnish v1 -vcl {
+	import ${vmod_dynamic};
+
+	backend v2 { .host = "${v2_addr}"; .port = "${v2_port}"; }
+
+	sub vcl_init {
+		new d1 = dynamic.director(
+		    port = "${s1_port}",
+		    via = v2,
+		    authority = "");
+	}
+
+	sub vcl_recv {
+		set req.backend_hint = d1.backend("localhost");
+	}
+
+	sub vcl_backend_error {
+		# the director may resolve ::1 first
+		return (retry);
+	}
+}
+
+client c1 {
+	txreq -url /baz
+	rxresp
+	expect resp.status == 200
+	expect resp.http.Authority == ""
+} -run
+
+varnish v3 -proto PROXY -vcl+backend {
+	import std;
+	import proxy;
+
+	sub vcl_recv {
+		set req.http.Authority = proxy.authority();
+	}
+
+	sub vcl_deliver {
+		set resp.http.Authority = req.http.Authority;
+	}
+} -start
+
+varnish v1 -vcl {
+	import ${vmod_dynamic};
+
+	backend b None;
+
+	sub vcl_init {
+		new d1 = dynamic.director(
+		    port = "${v3_port}",
+		    proxy_header = 2,
+		    authority = "authority.com");
+	}
+
+	sub vcl_recv {
+		set req.backend_hint = d1.backend("${v3_addr}");
+	}
+
+	sub vcl_backend_error {
+		# the director may resolve ::1 first
+		return (retry);
+	}
+}
+
+client c1 -connect ${v1_sock} {
+	txreq -url /quux
+	rxresp
+	expect resp.status == 200
+	expect resp.http.Authority == ""
 } -run
 
 # vtc diag only

--- a/src/vmod_dynamic.c
+++ b/src/vmod_dynamic.c
@@ -404,7 +404,7 @@ dynamic_add(VRT_CTX, struct dynamic_domain *dom, const struct res_info *info)
 	}
 	vrt.endpoint = &ep;
 
-	b->dir = VRT_new_backend(ctx, &vrt);
+	b->dir = VRT_new_backend(ctx, &vrt, dom->obj->via);
 	AN(b->dir);
 
 	DBG(ctx, dom, "add-backend %s", b->vcl_name);
@@ -848,7 +848,8 @@ vmod_director__init(VRT_CTX,
     VCL_INT proxy_header,
     VCL_BLOB resolver,
     VCL_ENUM ttl_from_s,
-    VCL_DURATION retry_after)
+    VCL_DURATION retry_after,
+    VCL_BACKEND via)
 {
 	struct vmod_dynamic_director *obj;
 
@@ -928,6 +929,8 @@ vmod_director__init(VRT_CTX,
 			    ttl_from_s);
 		obj->resolver = &res_gai;
 	}
+
+	obj->via = via;
 
 	Lck_New(&obj->mtx, lck_dir);
 

--- a/src/vmod_dynamic.c
+++ b/src/vmod_dynamic.c
@@ -365,12 +365,13 @@ dynamic_add(VRT_CTX, struct dynamic_domain *dom, const struct res_info *info)
 
 	switch (dom->obj->share) {
 	case DIRECTOR:
-		vrt.hosthdr = dom->obj->hosthdr;
+		vrt.authority = vrt.hosthdr = dom->obj->hosthdr;
 		VSB_printf(vsb, "%s(%s:%s)", dom->obj->vcl_name, b->ip_addr,
 		    dom_port(dom));
 		break;
 	case HOST:
-		vrt.hosthdr = dom->obj->hosthdr ? dom->obj->hosthdr : dom->addr;
+		vrt.authority = vrt.hosthdr =
+		    dom->obj->hosthdr ? dom->obj->hosthdr : dom->addr;
 		VSB_printf(vsb, "%s.%s(%s:%s)", dom->obj->vcl_name, dom->addr,
 		    b->ip_addr, dom_port(dom));
 		break;
@@ -805,8 +806,15 @@ static inline enum dynamic_share_e
 dynamic_share_parse(const char *share_s)
 {
 	switch (share_s[0]) {
-	case 'D':	return DIRECTOR;
-	case 'H':	return HOST;
+	case 'D':
+		switch (share_s[1]) {
+		case 'E':
+			return DEFAULT; break;
+		case 'I':
+			return DIRECTOR; break;
+		default:	INCOMPL();
+		}
+	case 'H':	return HOST; break;
 	default:	INCOMPL();
 	}
 }
@@ -931,6 +939,9 @@ vmod_director__init(VRT_CTX,
 	}
 
 	obj->via = via;
+	if (obj->share == DEFAULT)
+		obj->share = via ? HOST : DIRECTOR;
+
 
 	Lck_New(&obj->mtx, lck_dir);
 

--- a/src/vmod_dynamic.h
+++ b/src/vmod_dynamic.h
@@ -59,6 +59,7 @@ enum dynamic_status_e {
 };
 
 enum dynamic_share_e {
+	DEFAULT,
 	DIRECTOR,
 	HOST
 };

--- a/src/vmod_dynamic.h
+++ b/src/vmod_dynamic.h
@@ -166,6 +166,7 @@ struct vmod_dynamic_director {
 	VCL_DURATION				first_lookup_tmo;
 	unsigned				max_connections;
 	unsigned				proxy_header;
+	VCL_BACKEND				via;
 	VTAILQ_ENTRY(vmod_dynamic_director)	list;
 	VTAILQ_HEAD(,dynamic_domain)		active_domains;
 	VTAILQ_HEAD(,dynamic_domain)		purged_domains;

--- a/src/vmod_dynamic.h
+++ b/src/vmod_dynamic.h
@@ -155,6 +155,7 @@ struct vmod_dynamic_director {
 	char					*vcl_name;
 	char					*port;
 	const char				*hosthdr;
+	const char				*authority;
 	enum dynamic_share_e			share;
 	VCL_PROBE				probe;
 	VCL_ACL					whitelist;

--- a/src/vmod_dynamic.vcc
+++ b/src/vmod_dynamic.vcc
@@ -228,7 +228,8 @@ $Object director(
 	INT proxy_header			= 0,
 	BLOB resolver				= NULL,
 	ENUM { cfg, dns, min, max } ttl_from	= "cfg",
-	DURATION retry_after			= 30)
+	DURATION retry_after			= 30,
+	BACKEND via				= NULL)
 
 Description
 	Create a DNS director.
@@ -321,6 +322,10 @@ Parameters to set attributes of backends
 	- *max_connections* (defaults to zero, unlimited)
 	- *proxy_header* - version of the PROXY protocol to use, or zero
 	  to disable it (defaults to zero, valid versions are one or two)
+	- *via* backend to make the connection through with an
+	  additional PROXY protocol header containing the actual
+	  address to connect to. Primary use case is SSL/TLS onloading
+	  via haproxy.
 
 .. raw:: pdf
 

--- a/src/vmod_dynamic.vcc
+++ b/src/vmod_dynamic.vcc
@@ -67,13 +67,28 @@ details.
 BACKEND SHARING
 ===============
 
-By default (``share = DIRECTOR`` parameter), backends are shared per
-director: Only one backend per director instance and ip address (and
-optionally port) is created.
+The ``share`` parameter specifies if backends are shared per director
+or per hostname.
 
-The ``share = HOST`` parameter allows to limit sharing to backends
-created for the same hostname (``host`` argument to the ``.backend()``
-method).
+* ``share = "DIRECTOR"``
+
+  Default if ``via`` is not specified.
+
+  Backends are shared per director: Only one backend per director
+  instance and ip address (and optionally port) is created.
+
+* ``share = "HOST"``
+
+  Default if ``via`` is specified.
+
+  Sharing of backends is limited to the same hostname (``host``
+  argument to the ``.backend()`` method).
+
+  This is the default for ``via`` for the common use case of TLS: For
+  TLS connections, the TLS onloader usually should verify the server's
+  certificate based on a hostname. For this purpose, the dynamic
+  backend's name is put into the ``authority`` TLV, so, consequently,
+  the backend needs to be defined per hostname.
 
 .. _ref_vmod_dynamic_probe:
 
@@ -215,7 +230,7 @@ $Event event
 $Object director(
 	STRING port				= "http",
 	STRING host_header			= 0,
-	ENUM { DIRECTOR, HOST } share		= "DIRECTOR",
+	ENUM { DEFAULT, DIRECTOR, HOST } share	= "DEFAULT",
 	PROBE probe				= 0,
 	ACL whitelist				= 0,
 	DURATION ttl				= 3600,

--- a/src/vmod_dynamic.vcc
+++ b/src/vmod_dynamic.vcc
@@ -244,7 +244,8 @@ $Object director(
 	BLOB resolver				= NULL,
 	ENUM { cfg, dns, min, max } ttl_from	= "cfg",
 	DURATION retry_after			= 30,
-	BACKEND via				= NULL)
+	BACKEND via				= NULL,
+	STRING authority			= NULL)
 
 Description
 	Create a DNS director.
@@ -341,6 +342,15 @@ Parameters to set attributes of backends
 	  additional PROXY protocol header containing the actual
 	  address to connect to. Primary use case is SSL/TLS onloading
 	  via haproxy.
+	- *authority* if *via* is also set, then this value is set as
+	  the authority TLV in the PROXY header sent to the
+	  backend. The "true" backend may use the authority TLV to set
+	  the SNI in a TLS connection to a remote backend. If
+	  *authority* is set to the empty string, or if *via* is not
+	  set, then the TLV is not sent. If *via* is set but
+	  *authority* is not set, then the authority TLV is set to the
+	  value of *host_header* (which in turn may fall back to the
+	  the address string for the backend).
 
 .. raw:: pdf
 


### PR DESCRIPTION
Previously this was always set to the value of the VRT_backend host
header. That is still the default, but with the new parameter a
different value may be set, or the parameter may be set to the
empty string, to specify that no authority TLV should be sent.