### PR TITLE
Declare $ABI vrt.

### DIFF
--- a/src/vmod_dynamic.vcc
+++ b/src/vmod_dynamic.vcc
@@ -27,6 +27,7 @@
 # SUCH DAMAGE.
 
 $Module dynamic 3 "Varnish dynamic backends module"
+$ABI vrt
 
 .. role:: ref(emphasis)
 


### PR DESCRIPTION
As far as I can tell, the VMOD code conforms to VRT. @nigoroll please make your own judgment on that, I may have missed something.

VRT makes like easier when there's a Varnish version update that doesn't change the VRT version -- the VMOD usually doesn't have to be updated. With $ABI strict, we have to update the VMOD even if nothing changes except the Varnish commit ID.