### PR TITLE
Add `wait_timeout` and `wait_limit` support

### DIFF
--- a/src/vmod_dynamic.c
+++ b/src/vmod_dynamic.c
@@ -662,6 +662,8 @@ ref_add(VRT_CTX, struct dynamic_ref *r)
 	vrt.between_bytes_timeout = dom->obj->between_bytes_tmo;
 	vrt.max_connections = dom->obj->max_connections;
 	vrt.proxy_header = dom->obj->proxy_header;
+	vrt.backend_wait_timeout = dom->obj->wait_timeout;
+	vrt.backend_wait_limit = dom->obj->wait_limit;
 	assert(vrt.proxy_header <= 2);
 	INIT_OBJ(&ep, VRT_ENDPOINT_MAGIC);
 
@@ -1329,7 +1331,9 @@ vmod_director__init(VRT_CTX,
     VCL_DURATION retry_after,
     VCL_BACKEND via,
     VCL_INT keep,
-    VCL_STRING authority)
+    VCL_STRING authority,
+    VCL_DURATION wait_timeout,
+    VCL_INT wait_limit)
 {
 	struct vmod_dynamic_director *obj;
 
@@ -1403,6 +1407,8 @@ vmod_director__init(VRT_CTX,
 	obj->proxy_header = (unsigned)proxy_header;
 	obj->ttl_from = dynamic_ttl_parse(ttl_from_arg);
 	obj->keep = (unsigned)keep;
+	obj->wait_timeout = wait_timeout;
+	obj->wait_limit = wait_limit;
 
 	if (resolver != NULL) {
 		obj->resolver = &res_getdns;

--- a/src/vmod_dynamic.h
+++ b/src/vmod_dynamic.h
@@ -181,7 +181,9 @@ struct vmod_dynamic_director {
 	VCL_DURATION				between_bytes_tmo;
 	VCL_DURATION				domain_usage_tmo;
 	VCL_DURATION				first_lookup_tmo;
+	VCL_DURATION				wait_timeout;
 	unsigned				max_connections;
+	unsigned				wait_limit;
 	unsigned				proxy_header;
 	VCL_BACKEND				via;
 	VTAILQ_ENTRY(vmod_dynamic_director)	list;

--- a/src/vmod_dynamic.vcc
+++ b/src/vmod_dynamic.vcc
@@ -250,7 +250,9 @@ $Object director(
 	DURATION retry_after			= 30,
 	BACKEND via				= NULL,
 	INT keep				= 3,
-	STRING authority			= NULL)
+	STRING authority			= NULL,
+	DURATION wait_timeout = -1,
+	INT wait_limit = 0)
 
 Description
 	Create a DNS director.
@@ -382,6 +384,8 @@ Parameters to set attributes of backends
 	  argument. The main use case for this argument to
 	  `dynamic.director()`_ is to disable SNI by default by
 	  setting it to the empty string as ``authority = ""``.
+	- *wait_timeout* (defaults to global *backend_wait_timeout*)
+	- *wait_limit* (defaults to global *backend_wait_limit*)
 
 .. raw:: pdf
 


### PR DESCRIPTION
Support the new backend parameters added in Varnish 7.6 for backend connection queuing as per https://varnish-cache.org/docs/7.6/whats-new/changes-7.6.html