### PR TITLE
Revert "Handle src/vmod_vcs_version.txt"

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -49,5 +49,3 @@ vmod-querystring-*/
 
 vmod-*.tar.[gx]z
 *.spec
-
-src/vmod_vcs_version.txt

--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -34,10 +34,6 @@ nodist_libvmod_dynamic_la_SOURCES = \
 	vcc_dynamic_if.c \
 	vcc_dynamic_if.h
 
-vmod_vcs_version.txt: vcc_dynamic_if.c
-
-DISTCLEANFILES = vmod_vcs_version.txt
-
 $(srcdir)/dyn_getdns.c: vcc_dynamic_if.h
 $(srcdir)/dyn_resolver_gai.c: vcc_dynamic_if.h
 $(srcdir)/dyn_resolver_getdns.c: vcc_dynamic_if.h
@@ -64,7 +60,6 @@ TESTS = \
 
 dist_doc_DATA = \
 	vmod_dynamic.vcc \
-	vmod_vcs_version.txt \
 	$(TESTS)
 
 dist_man_MANS = \


### PR DESCRIPTION
This reverts commit 2b18abec24e8b51b0b316fa028ee01cad73fc533.

On 8.0, I'm getting:

```
/usr/bin/install -c -m 644 vmod_dynamic.vcc ./vmod_vcs_version.txt vtc/admin_health.vtc vtc/layer.vtc vtc/layer_probe.vtc vtc/layer_reload.vtc vtc/r00107.vtc vtc/stale_obj.vtc vtc/test01.vtc vtc/test02.vtc vtc/test03.vtc vtc/test04.vtc vtc/test05.vtc vtc/test06.vtc vtc/test07.vtc vtc/test08.vtc vtc/test09.vtc vtc/test10.vtc vtc/test11.vtc vtc/test12.vtc vtc/test13.vtc vtc/test14.vtc vtc/via.vtc vtc/via_uds.vtc vtc/nogetdns/resolver_init_error.vtc '/usr/share/doc/vmod-dynamic'
/bin/mkdir -p '/usr/lib/varnish/vmods'
install: can't stat './vmod_vcs_version.txt': No such file or directory
```

`vmod_vcs_version.txt` doesn't seem to be generated anymore, and reverting the original commit seems to do the job.